### PR TITLE
Fallback to tiff if libtiff is not found on macOS and Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -724,10 +724,10 @@ class pil_build_ext(build_ext):
         if feature.want("tiff"):
             _dbg("Looking for tiff")
             if _find_include_file(self, "tiff.h"):
-                lib_tiff = _find_library_file(self, "tiff")
-                if sys.platform in ["win32", "darwin"]:
-                    lib_tiff = _find_library_file(self, "libtiff")
-                feature.tiff = lib_tiff
+                feature.tiff = (
+                    sys.platform in ["win32", "darwin"]
+                    and _find_library_file(self, "libtiff")
+                ) or _find_library_file(self, "tiff")
 
         if feature.want("freetype"):
             _dbg("Looking for freetype")


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/8016

You can see that some of the jobs on your PR are failing because libtiff isn't found on macOS and Windows - https://github.com/python-pillow/Pillow/actions/runs/8838868584/job/24276907851?pr=8016#step:5:8488

If you look at the [original setup.py code](https://github.com/python-pillow/Pillow/blob/c3ded3abdaa64d4ba75445b43d09d4fcf3129d73/setup.py#L720-L725), you will see that it should fallback to tiff if libtiff isn't found, but your PR missed that. This fixes it.